### PR TITLE
애플기기 mulish 폰트 미적용 이슈

### DIFF
--- a/components/Welcom.js
+++ b/components/Welcom.js
@@ -46,13 +46,14 @@ const WelcomText = styled.div`
   font-family: 'Mulish-ExtraBold';
   margin: 0 auto;
   text-align: center;
-  h1 {
-    /* font-family: 'Mulish-ExtraBold'; */
+  word-break: keep-all;
+  /* h1 {
+    font-family: 'Mulish-ExtraBold';
     color: #ffd25e;
     font-size: 60px;
     font-weight: bolder;
     margin-bottom: 25px;
-  }
+  } */
   h2 {
     color: #fff;
     font-size: 30px;
@@ -78,9 +79,6 @@ const WelcomText = styled.div`
     span {
       display: block;
     }
-    h1 {
-      font-family: 'Muilsh-ExtraBold';
-    }
     h1,
     h2 {
       font-size: 20px;
@@ -93,6 +91,17 @@ const WelcomText = styled.div`
   }
 `;
 
+const WelcomeTitle = styled.div`
+  font-family: 'Mulish-ExtraBold';
+  color: #ffd25e;
+  font-size: 60px;
+  font-weight: bolder;
+  margin-bottom: 25px;
+  @media screen and (max-width: 1024px) {
+    font-size: 20px;
+  }
+`;
+
 const Welcom = () => {
   return (
     <WelcomContainer>
@@ -101,7 +110,7 @@ const Welcom = () => {
       {/* 백그라운드를 제외하고 싶다면 이 컴포넌트를 주석해주세요 */}
       <BackgroundBox />
       <WelcomText>
-        <h1>HACK YOUR LIFE</h1>
+        <WelcomeTitle>HACK YOUR LIFE</WelcomeTitle>
         <span>
           <h2>프로그래밍으로</h2>
           <h2>당신의 인생을 바꿔보세요!</h2>

--- a/components/Welcom.js
+++ b/components/Welcom.js
@@ -85,7 +85,7 @@ const WelcomText = styled.div`
     }
     p {
       margin: 8px auto 30px auto;
-      width: 165px;
+      /* width: 162px; */
       font-size: 10px;
     }
   }

--- a/components/Welcom.js
+++ b/components/Welcom.js
@@ -43,15 +43,11 @@ const BackgroundBox = styled.div`
 `;
 
 const WelcomText = styled.div`
-  @font-face {
-    font-family: 'Mulish-ExtraBold';
-    src: local('Mulish'),
-      url(${'/fonts/Mulish-ExtraBold.ttf'}) format('truetype');
-  }
+  font-family: 'Mulish-ExtraBold';
   margin: 0 auto;
   text-align: center;
   h1 {
-    font-family: 'Mulish-ExtraBold';
+    /* font-family: 'Mulish-ExtraBold'; */
     color: #ffd25e;
     font-size: 60px;
     font-weight: bolder;

--- a/styles/globalStyles.js
+++ b/styles/globalStyles.js
@@ -23,7 +23,7 @@ const GlobalStyle = createGlobalStyle`
   body{
     user-select: none;
     background-color: #ffffff;
-    font-family: -apple-system,Mulish,NanumGothic,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    font-family: Mulish,NanumGothic,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif, -apple-system;
     /* font-family: -apple-system,Mulish,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; */
     /* font-family: -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; */
   }

--- a/styles/globalStyles.js
+++ b/styles/globalStyles.js
@@ -12,6 +12,11 @@ const GlobalStyle = createGlobalStyle`
     url(${'/fonts/Mulish-Regular.ttf'}) format("truetype");
   }
   @font-face {
+    font-family: 'Mulish-ExtraBold';
+    src: local('Mulish'),
+      url(${'/fonts/Mulish-ExtraBold.ttf'}) format('truetype');
+  }
+  @font-face {
     font-family: "NanumGothicBold";
     src: local('NanumGothicBold'), url(${'/fonts/NanumGothicBold.ttf'}) format("truetype");
     // 한글만 해당 폰트 적용


### PR DESCRIPTION
애플기기에서 mulish 폰트가 적용되지 않는 현상 해결을 위한 브랜치
- IOS에서 많이 이슈가 되고 있음
- macOS의 경우 정상적으로 보임 (macOS에서 user-agent를 mobile safari로 해도 적상적으로 적용됨)